### PR TITLE
フラッシュメッセージの日本語化

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ Bundler.require(*Rails.groups)
 module ChatSpace
   class Application < Rails::Application
     config.time_zone = 'Tokyo'
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
# What
フラッシュメッセージを日本語化した
config/application.rbにconfig.i18n.default_locale = :jaを追加した
# Why
使用するuserが日本人を想定しているから
